### PR TITLE
Querying Particle Data from Database

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "C:\\Users\\Tyler\\anaconda3\\python.exe"
+}

--- a/data_collection.py
+++ b/data_collection.py
@@ -1,0 +1,47 @@
+import mysql.connector
+from mysql.connector import errorcode
+
+x_coords = []
+y_coords = []
+
+# cnx = mysql.connector.connect(user='meyercts_meyerct', password=',{xHc6evSy-b',
+#                               host='gator3315.hostgator.com', database='meyercts_particle_data')
+
+try:
+    cnx = mysql.connector.connect(user='meyercts_meyerct', password='WS_ZVp^sI)x@',
+                                  host='gator3315.hostgator.com', database='meyercts_particle_data')
+
+    selector = cnx.cursor()
+
+    query = ("SELECT x_coord FROM `data_table`")
+
+    selector.execute(query)
+
+    for x_coord in selector:
+        print(x_coord[0])
+        x_coords.append(x_coord[0])
+
+    selector.close()
+
+    selector = cnx.cursor()
+
+    query = ("SELECT y_coord FROM `data_table`")
+
+    selector.execute(query)
+
+    for y_coord in selector:
+        print(y_coord[0])
+        y_coords.append(y_coord[0])
+
+    print(x_coords)
+    print(y_coords)
+
+except mysql.connector.Error as err:
+    if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
+        print("Something is wrong with your user name or password")
+    elif err.errno == errorcode.ER_BAD_DB_ERROR:
+        print("Database does not exist")
+    else:
+        print(err)
+else:
+    cnx.close()


### PR DESCRIPTION
The MySQL database has been attached to the particle site, and particle data is pulled from each unique user to access the site and stored in the database.

On the python client side, you can now access the database and pull the coord data.

***NOTE***
To access the database, I need to add your home ip to the remote connection authorization.
Until I do this, you will get an access denied error when you try to run the code.